### PR TITLE
fix: tuning 관련 파일이 수정 되었을 때만 ci 작동하도록 수정

### DIFF
--- a/.github/workflows/docker-deploy-tuning.yml
+++ b/.github/workflows/docker-deploy-tuning.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     types: [closed]
     branches:
-    # - feature/docker-deploy
       - develop
     #  - main
+    paths:
+      - 'app-tuning/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker-deploy-tuning.yml'
   workflow_dispatch:
     inputs:
       env:
@@ -290,7 +293,7 @@ jobs:
             if [ "$ENV" = "production" ] || [ "$ENV" = "prod" ]; then
               CPU_LIMIT=3.5
             else
-              CPU_LIMIT=2.0
+              CPU_LIMIT=1.5
             fi
 
             # .env 파일에 이미지 정보 세팅

--- a/docker-compose-tuning.yml
+++ b/docker-compose-tuning.yml
@@ -1,15 +1,16 @@
 services:
-  tuning:
+  tuning-api:
     container_name: tuning
-    image: ${FULL_IMAGE} #${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/tuning-api:${IMAGE_TAG:-latest}
+    image: ${FULL_IMAGE}
     restart: always
     ports:
       - "8000:8000"
     cap_add:
       - SYS_PTRACE
     environment:
-      - UVICORN_WORKERS=1 # - CHROMA_HOST=chromadb
-      - CHROMA_HOST=host.docker.internal # ⬅️ 로컬 PM2 서버로 접속
+      - IS_PERSISTENT=TRUE
+      - UVICORN_WORKERS=1
+      - CHROMA_HOST=chromadb #   - CHROMA_HOST=host.docker.internal  # ⬅️ 로컬 PM2 서버로 접속
       - CHROMA_PORT=8001
       - CHROMA_MODE=server
       - TOKENIZERS_PARALLELISM=false
@@ -18,22 +19,41 @@ services:
       - /home/deploy/app-pylibs:/app/extlibs
       - tuning_logs:/app/logs
       - /home/deploy/models:/app/model-cache
-    depends_on: []
+    depends_on: [ chromadb ]
     deploy:
       resources:
         limits:
-          cpus: ${CPU_LIMIT:-1.5} # CPU 제한 (예: 2.0)
+          cpus: "1.5"
           memory: "11G"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8001/api/v1/health/chromadb" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/api/v1/health/chromadb" ]
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 60s
     extra_hosts:
-      - "host.docker.internal:172.17.0.1" # ⬅️ Linux 호스트 연결을 위한 강제 호스트 설정 
+      - "host.docker.internal:172.17.0.1" # ⬅️ Linux 호스트 연결을 위한 강제 호스트 설정
     networks:
       - app-network
+  chromadb:
+    container_name: chromadb
+    image: ghcr.io/chroma-core/chroma:0.4.13
+    volumes:
+      - ./chroma-data:/chroma/db # ← 로컬 경로 볼륨
+    ports:
+      - "8001:8001"
+    environment:
+      - CHROMA_SERVER_HTTP_PORT=8001
+      - IS_PERSISTENT=TRUE
+      - ALLOW_RESET=false
+      - ANONYMIZED_TELEMETRY=false
+      - IS_PERSISTENT=TRUE
+      - PERSIST_DIRECTORY=/chroma/db
+    restart: unless-stopped
+    command: uvicorn chromadb.app:app --host 0.0.0.0 --port 8001
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge


### PR DESCRIPTION
## #️⃣ Issue Number

[Sprint #4 - CL ] - AI docker 배포
[#164](https://github.com/100-hours-a-week/2-hertz-wiki/issues/164)

## 📝 요약(Summary)
tuning 관련 내용이 변경되었을 때에만 CI 작동 하도록 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 참고 자료 / 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
